### PR TITLE
Add section for farmers FAQ under agora

### DIFF
--- a/faq_setlist.md
+++ b/faq_setlist.md
@@ -1,0 +1,130 @@
+## Signing Up and Setting Up
+
+**How do I sign up for Agora?**
+
++ To sign up for Agora, please fill out the [registration form](https://docs.google.com/forms/d/e/1FAIpQLSfiG1ApbrGh2cOU_j51u8WjKA3WKeZiJuI77-9HIptS_hHNqw/viewform). A member of our team will reach out to you shortly!
+
+**What happens after I sign up?**
+
++ After you sign up, our team will create an Agora store for your farm. 
++ You will receive an email with your login credentials and instructions on how to access your Agora store. Once your store is created, you will be able to list produce and manage orders from customers. You can also manage your store's inventory and orders from the Agora dashboard.
+
+---
+
+## Managing my Agora Farmer Store
+
+**What is an Agora Farmer Store?**
+
++ An Agora Farmer Store is a digital storefront where you can list and sell your products directly to customers. Each farm listed on Agora has its own independent Store.
+
+**How do I add new products to my Agora Store?**
+
++ Once you've logged into [your store](https://farms.agora-on.ca/), click on the "Products" tab, then navigate to the "Products Listing" menu. Finally, click on "Add Product" and fill in the details, including description, price, and images. 
+
++ When a product is listed for the first time, the product's status will be listed as "Approval Pending". This is to ensure that products listed on Agora are relevant to our online marketplace.
+
++ Once approved, the product is published on the live site. All changes made to a product listing after approval will be visible near-instataneously. 
+
+**Can I manage multiple Agora Stores?**
+
++ At this point, only one Agora Store can be activated per farm.
+
+**How do I edit or update an existing product listing?**
+
++ Once you've logged into [your store](https://farms.agora-on.ca/), click on "Products Listing" tab, under "Products", locate the product to modify, and click "Edit". You can modify the description, update images, adjust pricing, or change stock levels. After saving, the updated listing will be live immediately.
+
+**What is the best way to set up inventory levels and receive low-stock alerts?**
+
++ In the product edit screen, set the current quantity "Uncer Variant Details", and "Quantity" field.
+
++ To view all product inventories at a glance, click on "Variant Inventory" under the "Products" tab.
+
+**Can I offer discounts on products?**
+
++ To offer per-product discounts, navigate to the product's listing under the Products page. 
+    + Change the "Price" field to the **new discounted price**.
+    + Change the "Compare At Price" as the **non-discounted price**.
+    + For example, if you want to provide a $2 discount on a product normally priced at $10, fill "Price" with $8, and "Compare At Price" with $10.
+    + > Note: The "Sales Price" field is automatically generated, and includes the per-product Agora fee.
+    
++ To create discount codes, navigate to **Products → Discount**, click **Add Discount**, fill in the 
+details (product‑specific or whole‑order, amount, limits, expiry), and hit 
+**Save Changes**. Your code is ready to use and can be shared.
+
+
+**How do I schedule or automate product listings for future dates?**
+
++ While adding or editing a product, use the "Publish Date" field to pick a future date. The product will automatically become visible on that day, which is ideal for seasonal launches or limited-time offers.
+
+**How do I change my in-store pickup hours?**
+
++ [TODO: Add details on whether those hours get used at the sales side automatically. IOW, do customers have a drop-down for pickup hours when ordering, or do they need to work with farm to determine an appropriate pickup time?]
+
++ To modify your pick-up hours, navigate to your store's settings under "Profile" and modify the "Hours" subsection.
+
+**What tools are available for tracking sales performance and customer traffic?**
+
++ The Agora Dashboard provides real-time analytics: total sales, as well as recent-orders, and inventory. 
+
++ For deeper analytics, you can also export reports (Products Reports, Orders Reports).
+    + For **Products**, navigate to "Products Listings", click on "More" and "Export Details".
+    + For **Orders**,  navigate to "Orders Listings", click on "More" and "Export Details".
+
+
+**How can I manage order cancellations or returns directly from the dashboard?**
+
++ [TOREVIEW: Is this correct?]
++ At launch, orders before fulfillment can be cancelled. Once an order is marked approved, the customer is no longer eligible for a refund. Agora does not support returns for produce.
+
+**How do I handle promotions or coupon codes?**
+
++ To create discount codes, navigate to **Products → Discount**, click **Add Discount**, fill in the 
+details (product‑specific or whole‑order, amount, limits, expiry), and hit 
+**Save Changes**. Your code is ready to use and can be shared.
+
+**What support is available if I encounter a technical issue with my store?**
++ [TOREVIEW: What other service level should we provide to farmers if they need immediate support?]
++ You can email support@agora.ca. Our team typically responds within a few hours and will guide you through any troubleshooting steps.
+
+**I am going on vacation. How can I disable my store?**
+
++ [TOREVIEW: What other service level should we provide to farmers if they need immediate support?]
++ To disable your store temporarily, you can send an email to support@agora.ca requesting a temporary disablement.
+
+---
+
+## Fulfilling Orders
+
+**What happens when a customer places an order?**
+
++ [TOREVIEW: Is process correct?]
++ When a customer places an order, you'll receive a notification to accept the order via email. Once accepted, the customer will pick up the order based on your store's opening hours.
+
+**How does fulfillment happen?**
+
++ [TOREVIEW: Is process correct?]
++ At launch, Agora only offers in-store pickup, based on the store's opening hours. Once the customer picks up the order, the order is marked complete by both the buyer and farmer.
+
+**How do I track my orders and shipments?**
+
++ [TOREVIEW: Is process correct?]
++ At launch, Agora only offers in-store pickup, based on the store's opening hours. Once the customer picks up the order, the order is marked complete by both the buyer and farmer.
+
+**What happens if I encounter issues with an order?**
+
++ [TOREVIEW: What other service level should we provide to farmers if they need immediate support?]
++ If you have any issues with an order, contact our support team for assistance.
+
+---
+
+## Financials
+
+**How often does Agora distribute payments to store-owners?**
+
++ [TOREVIEW: Is process correct?]
++ Agora Inc. distributes payments to store-owners at the end of every business day for fulfilled orders.
+
+**Does Agora collect sales tax?**
+
++ [TOREVIEW: How do we do that?]
+TBD

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <div class="nav-links">
           <a href="#about">About</a>
           <a href="#contact">Contact</a>
+          <a href="#faq">FAQ</a>
         </div>
         <div class="mobile-menu" id="mobileMenu">
           <span></span>
@@ -139,6 +140,170 @@
           </div>
         </div>
       </section>
+
+      <!-- FAQ Section -->
+      <section id="faq">
+        <div class="container">
+          <div class="bento-grid about-grid">
+            <div class="bento-item about-main">
+              <h2>Frequently Asked Questions</h2>
+              <h3>For Farmers</h3>
+
+              <h4> Signing Up and Setting Up</h4>              
+                <ol>
+                  <li>                  
+                    <details>
+                      <summary>How do I do sign up for Agora?</summary>
+                      To sign up for Agora, navigate to the "Join" button and fill out the registration form. A member of our team will reach out to you shortly!
+                    </details>
+                  </li>           
+                  
+                  <li>                  
+                    <details>
+                      <summary>What happens after I sign up?</summary>
+                      After you sign up, our team will create an Agora store for your farm. You will receive an email with your login credentials and instructions on how to access your Agora store. 
+                      <br> Once your store is created, you will be able to list produce and manage orders from customers. 
+                      You can also manage your store's inventory and orders from the Agora dashboard.
+                    </details>
+                  </li>     
+                </ol>
+
+              <h4> Managing my Agora Farmer Stall</h4>              
+              <ol>
+                <li>
+                  <details>
+                    <summary>What is an Agora Farmer Stall?</summary>
+                    An Agora Farmer Stall is a digital storefront where you can list and sell your products directly to customers. Each farm listed on Agora has its own independent stall.
+                  </details>
+                </li>
+                <li>
+                  <details>
+                    <summary>How do I add new products to my Agora Stall?</summary>
+                    Once you are in your store, click on the "Products" tab, then navigate to the "Products Listing" menu. Finally, click on "Add Product" and fill in the details, including description, price, and images. To ensure that products are relevant to our online marketplace, each new product is approved by our team.
+                  </details>
+                </li>
+                <li>
+                  <details>
+                    <summary>Can I manage multiple Agora Stalls?</summary>
+                    At this point, each farm can only have one Agora Stall.
+                  </details>
+                </li>
+                  <li>
+                    <details>
+                      <summary>How do I edit or update an existing product listing?</summary>
+                      If your produce is "live", navigate to the "Products" tab, locate the product, and click "Edit". You can modify the description, update images, adjust pricing, or change stock levels. After saving, the updated listing will be live immediately.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>What is the best way to set up inventory levels and receive low‑stock alerts? - <em>TO CONFIRM</em></summary>
+                      In the product edit screen, set the current quantity in the "Inventory" field. Enable the “Low‑Stock Alert” toggle to receive an email when stock falls below the threshold you specify. This helps you restock in time and avoid selling out of products.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>Can I offer discounts on products?</summary>
+                      Yes—under the product’s listing, you can apply discounted pricing to a specific product.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>How do I schedule or automate product listings for future dates?<em>TO CONFIRM</em></summary>
+                      While adding or editing a product, use the “Publish Date” field to pick a future date. The product will automatically become visible on that day, which is ideal for seasonal launches or limited‑time offers.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>How do I change my in-store pickup hours?<em>TO CONFIRM</em></summary>
+                      To modify your pick-up hours, navigate to your store’s settings and adjust the “Pick-up Hours” field.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>What tools are available for tracking sales performance and customer traffic?</summary>
+                      The Agora Dashboard provides real‑time analytics: total sales, average order value, most‑sold items, and traffic sources. Export reports in CSV or PDF for deeper analysis.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>How can I manage order cancellations or returns directly from the dashboard?</summary>
+                      At launch, order cancellations before fulfillment can be cancelled. Once a order is marked approved, the customer is no longer eligible for a refund. Agora does not support returns for produce.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>How do I handle promotions or coupon codes? <em>TO CONFIRM</em></summary>
+                      In the “Promotions” section, click “Create Coupon”. Define the discount type (percentage, fixed amount), expiration date, usage limits, and applicable products or categories. Share the coupon code with customers via email or social media.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>What support is available if I encounter a technical issue with my store?</summary>
+                      You can also email support@agora.ca. Our team typically responds within a few hours and will guide you through any troubleshooting steps.
+                    </details>
+                  </li>
+                  <li>
+                    <details>
+                      <summary>I am going on vacation. How can I disable my store? <em>TO CONFIRM</em></summary>
+                      To disable your store temporarily, you can send an email to support@agora.ca requesting a temporary disablement.
+                    </details>
+                  </li>
+              </ol>
+
+              <h4>Fulfilling Orders</h4 >
+              <ol>
+                <li>
+                  <details>
+                    <summary>What happens when a customer places an order?<em>TO CONFIRM</em></summary>
+                    When a customer places an order, you'll receive a notification to accept the order. Once accepted, the customer will pick up the order based on your store's opening hours.
+                  </details>
+                </li>
+                <li>
+                  <details>
+                    <summary>How does fulfillment happen?<em>TO CONFIRM</em></summary>
+                    At launch, Agora only offers in-store pickup, based on the store's opening hours. Once the customer picks up the order, the order is marked complete by both the buyer and farmer. 
+                  </details>
+                </li>
+                <li>
+                  <details>
+                    <summary>How do I track my orders and shipments?<em>TO CONFIRM</em></summary>
+                    Use the "Order Management" feature to view all your orders, filter them by status, and track shipments in real-time.
+                  </details>
+                </li>
+                <li>
+                  <details>
+                    <summary>What happens if I encounter issues with an order?</summary>
+                    If you have any issues with an order, contact our support team for assistance.
+                  </details>
+                </li>
+              </ol>
+              
+              <h4>Financials</h4 >
+              <ol>
+                <li>
+                  <details>
+                    <summary>How often does Agora distribute payments to store-owners? <em>TO CONFIRM</em></summary>
+                    Agora Inc. distributes payments to store-owners at the end of every business day for fulfilled orders.
+                  </details>
+                </li>
+                <li>
+                  <details>
+                    <summary>Does Agora collect sales tax? <em>TO CONFIRM</em></summary>
+                    TBD
+                  </details>
+                </li>
+            
+            </div>
+
+            <!-- <div class="bento-item join-card">
+              <h3>Ready to Join?</h3>
+              <p>Start connecting with your local food community today</p>
+              <button class="join-btn">Join Agora</button>
+            </div> -->
+          </div>
+        </div>
+      </section>
+
 
       <!-- Contact Section -->
       <section id="contact" class="contact">

--- a/style.css
+++ b/style.css
@@ -630,3 +630,7 @@ body {
     padding: 1rem;
   }
 }
+
+/* FAQ list & disclosure styles */
+#faq ol{margin-left:1rem;list-style:none;}
+#faq ol li::marker{content:counter(list-item,decimal)". ";color:#006600;font-weight:400;}


### PR DESCRIPTION
Hey all!

Here's a quick PR as we develop `FAQ` content for farmers.

I've created the PR from `sr/create-basic-faq-same-page` into `development`. I anticipate there's going some back and forth on the content before it being ready to go to `main` hence why.

**Of note:**
1. HTML and css changes are mostly structural and have not changed since last week (`index.html`, `styles.css`).
2. I figure there's going to be back and forth re: wording/question set etc. To make that easier to track, I created a separate markdown document for us to develop the FAQ (that's the `faq_setlist.md` file). Once we finalise the FAQ content, then we can copy/paste that into the html bit to save us some trouble.
3. As you review `faq_setlist.md`, I sprinkled in some `[TODO]` or `[TOREVIEW]`. Ctrl+F these, as these require extra attention :)
4. Open to all changes re: FAQ content, and better html/css approaches to present the info as well :)
